### PR TITLE
Only read first entity snapshot from GOTV demos, fix position jittering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
-### 0.6.1 (2023-12-21)
+### 0.6.1 (2023-12-23)
 
 - Only read the first entity snapshot in GOTV demos (~10% perf improvement)
 - Added `DemoFile.IsGotv`, indicating whether the demo was recorded by GOTV
+- Fix pawn position jumping to multiples of 1024 for a single tick (https://github.com/saul/demofile-net/issues/27)
 
 ### 0.5.1 (2023-12-19)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 0.6.1 (2023-12-21)
+
+- Only read the first entity snapshot in GOTV demos (~10% perf improvement)
+- Added `DemoFile.IsGotv`, indicating whether the demo was recorded by GOTV
+
 ### 0.5.1 (2023-12-19)
 
 - Fix decode exception caused by .NET runtime bug (https://github.com/dotnet/runtime/issues/96174)

--- a/src/DemoFile.SdkGen/Program.cs
+++ b/src/DemoFile.SdkGen/Program.cs
@@ -656,7 +656,16 @@ internal static class Program
                     builder.AppendLine($"            var decoder = {decoderMethod}(field.FieldEncodingInfo);");
                     builder.AppendLine($"            return ({classNameCs} @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>");
                     builder.AppendLine($"            {{");
-                    builder.AppendLine($"                @this.{fieldCsPropertyName} = decoder(ref buffer);");
+
+                    if (serializer == null)
+                    {
+                        builder.AppendLine($"                @this.{fieldCsPropertyName} = decoder(ref buffer);");
+                    }
+                    else
+                    {
+                        builder.AppendLine($"                @this.{fieldCsPropertyName} = decoder(@this, ref buffer);");
+                    }
+
                     builder.AppendLine($"            }};");
                 }
 

--- a/src/DemoFile.Test/Integration/DemoParserIntegrationTest.cs
+++ b/src/DemoFile.Test/Integration/DemoParserIntegrationTest.cs
@@ -13,31 +13,6 @@ public class DemoParserIntegrationTest
         await demo.Start(GotvCompetitiveProtocol13963, default);
     }
 
-    [Test]
-    public async Task Parse_DemoEvents()
-    {
-        // Arrange
-        var snapshot = new StringBuilder();
-        var demo = new DemoParser();
-
-        demo.DemoEvents.DemoFileInfo += e =>
-        {
-            snapshot.AppendLine($"[{demo.CurrentDemoTick}/{demo.CurrentGameTick}] TickCount={demo.TickCount}");
-            snapshot.AppendLine($"[{demo.CurrentDemoTick}/{demo.CurrentGameTick}] DemoFileInfo: {JsonSerializer.Serialize(e, DemoJson.SerializerOptions)}");
-        };
-
-        demo.PacketEvents.SvcServerInfo += e =>
-        {
-            snapshot.AppendLine($"[{demo.CurrentDemoTick}/{demo.CurrentGameTick}] SvcServerInfo: {JsonSerializer.Serialize(e, DemoJson.SerializerOptions)}");
-        };
-
-        // Act
-        await demo.Start(GotvCompetitiveProtocol13963, default);
-
-        // Assert
-        Snapshot.Assert(snapshot.ToString());
-    }
-
     private static readonly KeyValuePair<string, Stream>[] CompatibilityCases =
     {
         new("v13978", GotvProtocol13978),

--- a/src/DemoFile.Test/Integration/DemoParserIntegrationTest.cs
+++ b/src/DemoFile.Test/Integration/DemoParserIntegrationTest.cs
@@ -1,4 +1,7 @@
-﻿namespace DemoFile.Test.Integration;
+﻿using System.Text;
+using System.Text.Json;
+
+namespace DemoFile.Test.Integration;
 
 [TestFixture]
 public class DemoParserIntegrationTest
@@ -8,6 +11,31 @@ public class DemoParserIntegrationTest
     {
         var demo = new DemoParser();
         await demo.Start(GotvCompetitiveProtocol13963, default);
+    }
+
+    [Test]
+    public async Task Parse_DemoEvents()
+    {
+        // Arrange
+        var snapshot = new StringBuilder();
+        var demo = new DemoParser();
+
+        demo.DemoEvents.DemoFileInfo += e =>
+        {
+            snapshot.AppendLine($"[{demo.CurrentDemoTick}/{demo.CurrentGameTick}] TickCount={demo.TickCount}");
+            snapshot.AppendLine($"[{demo.CurrentDemoTick}/{demo.CurrentGameTick}] DemoFileInfo: {JsonSerializer.Serialize(e, DemoJson.SerializerOptions)}");
+        };
+
+        demo.PacketEvents.SvcServerInfo += e =>
+        {
+            snapshot.AppendLine($"[{demo.CurrentDemoTick}/{demo.CurrentGameTick}] SvcServerInfo: {JsonSerializer.Serialize(e, DemoJson.SerializerOptions)}");
+        };
+
+        // Act
+        await demo.Start(GotvCompetitiveProtocol13963, default);
+
+        // Assert
+        Snapshot.Assert(snapshot.ToString());
     }
 
     private static readonly KeyValuePair<string, Stream>[] CompatibilityCases =

--- a/src/DemoFile.Test/Integration/PlayerPropsIntegrationTest.cs
+++ b/src/DemoFile.Test/Integration/PlayerPropsIntegrationTest.cs
@@ -79,9 +79,7 @@ public class PlayerPropsIntegrationTest
                 OnSnapshotTimer);
         }
 
-        demo.CreateTimer(
-            demo.CurrentDemoTick + playerSnapshotInterval,
-            OnSnapshotTimer);
+        demo.CreateTimer(DemoTick.Zero + playerSnapshotInterval, OnSnapshotTimer);
 
         // Act
         await demo.Start(GotvCompetitiveProtocol13963, default);

--- a/src/DemoFile.Test/Integration/StringTableIntegrationTest.cs
+++ b/src/DemoFile.Test/Integration/StringTableIntegrationTest.cs
@@ -41,9 +41,7 @@ public class StringTableIntegrationTest
                 OnSnapshotTimer);
         }
 
-        demo.CreateTimer(
-            demo.CurrentDemoTick + playerSnapshotInterval,
-            OnSnapshotTimer);
+        demo.CreateTimer(DemoTick.Zero + playerSnapshotInterval, OnSnapshotTimer);
 
         // Act
         await demo.Start(GotvCompetitiveProtocol13963, default);

--- a/src/DemoFile.Test/Snapshots/Position.txt
+++ b/src/DemoFile.Test/Snapshots/Position.txt
@@ -518,8 +518,8 @@
     "Deaths": 1,
     "LastPlaceName": "Catwalk",
     "Origin": {
-      "X": -2048,
-      "Y": -1024,
+      "X": -1126.9736,
+      "Y": -457.4879,
       "Z": -167.96875
     },
     "Rotation": {
@@ -1253,8 +1253,8 @@
     "LastPlaceName": "Connector",
     "ActiveWeapon": "CKnife",
     "Origin": {
-      "X": -1024,
-      "Y": -1024,
+      "X": -638.097,
+      "Y": -989.56744,
       "Z": -215.96875
     },
     "Rotation": {
@@ -1882,8 +1882,8 @@
     "LastPlaceName": "CTSpawn",
     "ActiveWeapon": "CKnife",
     "Origin": {
-      "X": -2048,
-      "Y": -1024,
+      "X": -1323.4896,
+      "Y": -972.37964,
       "Z": -167.96875
     },
     "Rotation": {
@@ -2938,8 +2938,8 @@
     "Deaths": 3,
     "LastPlaceName": "TopofMid",
     "Origin": {
-      "X": 142.0862,
-      "Y": -562.2657,
+      "X": 142.30609,
+      "Y": -561.48395,
       "Z": -166.96875
     },
     "Rotation": {
@@ -2954,7 +2954,7 @@
     },
     "Weapons": []
   }
-[157935] Interval snapshot:
+[157934] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",
@@ -3032,13 +3032,13 @@
     "LastPlaceName": "Apartments",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": -1834.6072,
-      "Y": 761.71326,
+      "X": -1836.4205,
+      "Y": 761.94495,
       "Z": -47.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -11.749878,
+      "Yaw": -11.696655,
       "Roll": 0
     },
     "EyeAngles": {
@@ -3244,18 +3244,18 @@
     "LastPlaceName": "Catwalk",
     "ActiveWeapon": "CWeaponGalilAR",
     "Origin": {
-      "X": -990.98285,
-      "Y": -116.51825,
+      "X": -992.00696,
+      "Y": -117.87042,
       "Z": -167.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -37.28279,
+      "Yaw": -37.21756,
       "Roll": 0
     },
     "EyeAngles": {
       "Pitch": 3.0360107,
-      "Yaw": -37.34012,
+      "Yaw": -37.252228,
       "Roll": 0
     },
     "Weapons": [
@@ -3325,18 +3325,18 @@
     "LastPlaceName": "BombsiteA",
     "ActiveWeapon": "CAK47",
     "Origin": {
-      "X": -1007.3092,
-      "Y": -2323.6953,
-      "Z": -163.04382
+      "X": -1004.04236,
+      "Y": -2324.4055,
+      "Z": -167.55713
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 169.51184,
+      "Yaw": 168.38437,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 5.3063965,
-      "Yaw": 174.82062,
+      "Pitch": 6.1777496,
+      "Yaw": 173.35535,
       "Roll": 0
     },
     "Weapons": [
@@ -3441,7 +3441,7 @@
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -168.02112,
+      "Yaw": -168.0201,
       "Roll": 0
     },
     "EyeAngles": {
@@ -3552,8 +3552,8 @@
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 11.329987,
-      "Yaw": -167.46391,
+      "Pitch": 10.120117,
+      "Yaw": -174.17381,
       "Roll": 0
     },
     "Weapons": [
@@ -3639,18 +3639,18 @@
     "LastPlaceName": "Middle",
     "ActiveWeapon": "CWeaponGalilAR",
     "Origin": {
-      "X": -114.64331,
-      "Y": -775.05,
-      "Z": -215.84283
+      "X": -115.2829,
+      "Y": -775.86475,
+      "Z": -215.97913
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 142.23312,
+      "Yaw": 142.2987,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": -0.1538086,
-      "Yaw": 141.68277,
+      "Pitch": -0.1980896,
+      "Yaw": 141.85855,
       "Roll": 0
     },
     "Weapons": [
@@ -4062,9 +4062,9 @@
     "LastPlaceName": "CTSpawn",
     "ActiveWeapon": "CAK47",
     "Origin": {
-      "X": -2048,
-      "Y": -2048,
-      "Z": -1024
+      "X": -2018.3505,
+      "Y": -1823.3798,
+      "Z": -297.2268
     },
     "Rotation": {
       "Pitch": 0,
@@ -4580,7 +4580,7 @@
     "Origin": {
       "X": -1017.2227,
       "Y": -2476.8035,
-      "Z": -1024
+      "Z": -167.96875
     },
     "Rotation": {
       "Pitch": 0,
@@ -4881,9 +4881,9 @@
     "Deaths": 7,
     "LastPlaceName": "TopofMid",
     "Origin": {
-      "X": 0,
-      "Y": -1024,
-      "Z": -1024
+      "X": 188.59584,
+      "Y": -531.34357,
+      "Z": -163.02185
     },
     "Rotation": {
       "Pitch": 0,
@@ -5732,8 +5732,8 @@
     "Deaths": 6,
     "LastPlaceName": "BombsiteB",
     "Origin": {
-      "X": -1325.0907,
-      "Y": 284.59473,
+      "X": -1324.726,
+      "Y": 284.8755,
       "Z": -167.96875
     },
     "Rotation": {
@@ -6053,7 +6053,7 @@
     "Origin": {
       "X": -1314.4999,
       "Y": -967.75,
-      "Z": -1024
+      "Z": -168.49866
     },
     "Rotation": {
       "Pitch": 0,
@@ -6101,7 +6101,7 @@
     },
     "Weapons": []
   }
-[196335] Interval snapshot:
+[196334] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",
@@ -6302,8 +6302,8 @@
     "LastPlaceName": "Shop",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": -2305.2866,
-      "Y": -466.25098,
+      "X": -2304.964,
+      "Y": -468.00244,
       "Z": -167.96875
     },
     "Rotation": {
@@ -6443,18 +6443,18 @@
     "LastPlaceName": "BombsiteA",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": 141.79317,
-      "Y": -1981.8328,
-      "Z": -131.51099
+      "X": 140.36563,
+      "Y": -1982.4438,
+      "Z": -134.29114
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -15.673035,
+      "Yaw": -12.371292,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": -7.9135895,
-      "Yaw": -64.27139,
+      "Pitch": -9.147827,
+      "Yaw": -53.091087,
       "Roll": 0
     },
     "Weapons": [
@@ -6553,13 +6553,13 @@
     "LastPlaceName": "Jungle",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": -1223.9816,
+      "X": -1224.6986,
       "Y": -1526.9688,
-      "Z": -152.56763
+      "Z": -152.49683
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 82.559845,
+      "Yaw": 82.55884,
       "Roll": 0
     },
     "EyeAngles": {
@@ -6710,9 +6710,9 @@
     "LastPlaceName": "SideAlley",
     "ActiveWeapon": "CWeaponAWP",
     "Origin": {
-      "X": 349.57492,
-      "Y": 141.81766,
-      "Z": -241.30621
+      "X": 349.91104,
+      "Y": 143.31969,
+      "Z": -241.84888
     },
     "Rotation": {
       "Pitch": 0,
@@ -6864,18 +6864,18 @@
     "LastPlaceName": "Underpass",
     "ActiveWeapon": "CAK47",
     "Origin": {
-      "X": -1046.6476,
-      "Y": 152.36642,
+      "X": -1046.7396,
+      "Y": 154.05153,
       "Z": -367.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -81.750984,
+      "Yaw": -81.799736,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": -5.0818634,
-      "Yaw": -81.723175,
+      "Pitch": -5.037918,
+      "Yaw": -81.76712,
       "Roll": 0
     },
     "Weapons": [
@@ -7296,9 +7296,9 @@
     "Deaths": 8,
     "LastPlaceName": "Underpass",
     "Origin": {
-      "X": -1024,
-      "Y": -1024,
-      "Z": -1024
+      "X": -973.2541,
+      "Y": -158.43628,
+      "Z": -367.96875
     },
     "Rotation": {
       "Pitch": 0,
@@ -8369,7 +8369,7 @@
     "Origin": {
       "X": 17.928162,
       "Y": -2234.481,
-      "Z": -1024
+      "Z": -39.96875
     },
     "Rotation": {
       "Pitch": 0,
@@ -8587,7 +8587,7 @@
     },
     "Weapons": []
   }
-[234735] Interval snapshot:
+[234734] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",
@@ -8752,12 +8752,12 @@
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 80.32037,
+      "Yaw": 80.48102,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": -1.782196,
-      "Yaw": 62.57675,
+      "Pitch": -1.8017578,
+      "Yaw": 62.497437,
       "Roll": 0
     },
     "Weapons": [
@@ -8814,13 +8814,13 @@
     "LastPlaceName": "Catwalk",
     "ActiveWeapon": "CWeaponP250",
     "Origin": {
-      "X": -558.7208,
-      "Y": -494.31268,
-      "Z": -166.13098
+      "X": -558.94745,
+      "Y": -494.43066,
+      "Z": -166.13165
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 117.5101,
+      "Yaw": 117.513885,
       "Roll": 0
     },
     "EyeAngles": {
@@ -8883,7 +8883,7 @@
     "ActiveWeapon": "CWeaponGlock",
     "Origin": {
       "X": -1247.9696,
-      "Y": -562.28766,
+      "Y": -563.4946,
       "Z": -167.96875
     },
     "Rotation": {
@@ -8901,7 +8901,7 @@
         "Class": "CKnife",
         "Weapon": "weapon_bayonet",
         "PaintKit": {
-          "Name": "am_doppler_phase3"
+          "Name": "default"
         },
         "Quality": "Unusual",
         "Rarity": "Common",
@@ -8950,18 +8950,18 @@
     "LastPlaceName": "Connector",
     "ActiveWeapon": "CWeaponGlock",
     "Origin": {
-      "X": -780.4675,
-      "Y": -1022.99225,
+      "X": -781.2559,
+      "Y": -1023.2875,
       "Z": -167.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -69.4796,
+      "Yaw": -69.42982,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 0.13183594,
-      "Yaw": -69.50844,
+      "Pitch": 0.17611694,
+      "Yaw": -69.46449,
       "Roll": 0
     },
     "Weapons": [
@@ -8969,7 +8969,7 @@
         "Class": "CKnife",
         "Weapon": "weapon_knife_stiletto",
         "PaintKit": {
-          "Name": "am_marble_fade"
+          "Name": "default"
         },
         "Quality": "Unusual",
         "Rarity": "Common",
@@ -9134,7 +9134,7 @@
         "Class": "CWeaponHKP2000",
         "Weapon": "weapon_usp_silencer",
         "PaintKit": {
-          "Name": "default"
+          "Name": "cu_usps_noir"
         },
         "Quality": "Unique",
         "Rarity": "Common",
@@ -9167,8 +9167,8 @@
     "LastPlaceName": "BombsiteB",
     "ActiveWeapon": "CWeaponElite",
     "Origin": {
-      "X": -2021.277,
-      "Y": 366.3002,
+      "X": -2021.8165,
+      "Y": 363.94922,
       "Z": -159.96875
     },
     "Rotation": {
@@ -9300,8 +9300,8 @@
     "LastPlaceName": "PalaceInterior",
     "ActiveWeapon": "CWeaponElite",
     "Origin": {
-      "X": 365.1959,
-      "Y": -1944.0397,
+      "X": 365.13593,
+      "Y": -1944.0347,
       "Z": -39.96875
     },
     "Rotation": {
@@ -9423,8 +9423,8 @@
     "Deaths": 8,
     "LastPlaceName": "BombsiteA",
     "Origin": {
-      "X": -1024,
-      "Y": -3072,
+      "X": -924.03253,
+      "Y": -2365.103,
       "Z": -167.96875
     },
     "Rotation": {
@@ -10206,9 +10206,9 @@
     "Deaths": 6,
     "LastPlaceName": "SnipersNest",
     "Origin": {
-      "X": -2048,
-      "Y": -1024,
-      "Z": -1024
+      "X": -1181.9132,
+      "Y": -530.4367,
+      "Z": -167.96875
     },
     "Rotation": {
       "Pitch": 0,
@@ -10678,7 +10678,7 @@
     "Origin": {
       "X": -1790.1093,
       "Y": 421.96622,
-      "Z": -1024
+      "Z": -166.28693
     },
     "Rotation": {
       "Pitch": 0,
@@ -11904,7 +11904,7 @@
     },
     "Weapons": []
   }
-[273135] Interval snapshot:
+[273134] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",
@@ -11982,9 +11982,9 @@
     "LastPlaceName": "TopofMid",
     "ActiveWeapon": "CAK47",
     "Origin": {
-      "X": 503.26428,
-      "Y": -456.07764,
-      "Z": -159.99243
+      "X": 503.20663,
+      "Y": -454.9369,
+      "Z": -159.99426
     },
     "Rotation": {
       "Pitch": 0,
@@ -12092,18 +12092,18 @@
     "LastPlaceName": "TopofMid",
     "ActiveWeapon": "CAK47",
     "Origin": {
-      "X": 0,
-      "Y": -1024,
-      "Z": -1024
+      "X": 499.50363,
+      "Y": -622.48334,
+      "Z": -160.11359
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 144.62952,
+      "Yaw": 144.89801,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 1.5047913,
-      "Yaw": 143.28162,
+      "Pitch": 1.4453888,
+      "Yaw": 138.74738,
       "Roll": 0
     },
     "Weapons": [
@@ -12215,8 +12215,8 @@
     "LastPlaceName": "Underpass",
     "ActiveWeapon": "CWeaponGalilAR",
     "Origin": {
-      "X": -930.26447,
-      "Y": 465.84125,
+      "X": -931.2329,
+      "Y": 466.15787,
       "Z": -367.96875
     },
     "Rotation": {
@@ -12312,18 +12312,18 @@
     "LastPlaceName": "SideAlley",
     "ActiveWeapon": "CAK47",
     "Origin": {
-      "X": 0,
-      "Y": 0,
-      "Z": -1024
+      "X": 241.293,
+      "Y": 94.06733,
+      "Z": -222.78912
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 52.321014,
+      "Yaw": 52.29698,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 1.0890198,
-      "Yaw": 52.324097,
+      "Pitch": 1.125412,
+      "Yaw": 52.360504,
       "Roll": 0
     },
     "Weapons": [
@@ -12409,18 +12409,18 @@
     "LastPlaceName": "BackAlley",
     "ActiveWeapon": "CWeaponGalilAR",
     "Origin": {
-      "X": -916.93756,
-      "Y": 564.013,
-      "Z": -81.74481
+      "X": -916.6452,
+      "Y": 565.0045,
+      "Z": -81.75012
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 163.49545,
+      "Yaw": 163.56342,
       "Roll": 0
     },
     "EyeAngles": {
       "Pitch": -2.4640198,
-      "Yaw": 163.43124,
+      "Yaw": 163.51913,
       "Roll": 0
     },
     "Weapons": [
@@ -12506,13 +12506,13 @@
     "LastPlaceName": "BombsiteA",
     "ActiveWeapon": "CWeaponMP9",
     "Origin": {
-      "X": 122.0562,
-      "Y": -1709.7021,
+      "X": 122.3635,
+      "Y": -1709.9886,
       "Z": -167.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 59.334076,
+      "Yaw": 59.263687,
       "Roll": 0
     },
     "EyeAngles": {
@@ -12624,9 +12624,9 @@
     "LastPlaceName": "BombsiteB",
     "ActiveWeapon": "CKnife",
     "Origin": {
-      "X": -2170.4429,
-      "Y": 557.53174,
-      "Z": -159.32507
+      "X": -2170.393,
+      "Y": 556.03186,
+      "Z": -159.68604
     },
     "Rotation": {
       "Pitch": 0,
@@ -12705,18 +12705,18 @@
     "LastPlaceName": "Middle",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": -964.36786,
-      "Y": -580.2028,
-      "Z": -274.47235
+      "X": -965.8047,
+      "Y": -579.0725,
+      "Z": -275.27313
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 7.256134,
+      "Yaw": 7.2767334,
       "Roll": 0
     },
     "EyeAngles": {
       "Pitch": -2.090149,
-      "Yaw": 7.25441,
+      "Yaw": 7.2767334,
       "Roll": 0
     },
     "Weapons": [
@@ -12815,18 +12815,18 @@
     "LastPlaceName": "Underpass",
     "ActiveWeapon": "CFlashbang",
     "Origin": {
-      "X": -1067.7012,
-      "Y": -424.48157,
+      "X": -1068.36,
+      "Y": -423.16412,
       "Z": -263.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -11.196106,
+      "Yaw": -10.508759,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 4.505432,
-      "Yaw": -20.559875,
+      "Pitch": 4.5936584,
+      "Yaw": -18.658905,
       "Roll": 0
     },
     "Weapons": [
@@ -13223,7 +13223,7 @@
         "Class": "CKnife",
         "Weapon": "weapon_knife_stiletto",
         "PaintKit": {
-          "Name": "default"
+          "Name": "am_marble_fade"
         },
         "Quality": "Unusual",
         "Rarity": "Common",
@@ -13368,9 +13368,9 @@
     "Deaths": 12,
     "LastPlaceName": "BombsiteB",
     "Origin": {
-      "X": -3072,
-      "Y": -1024,
-      "Z": -1024
+      "X": -2265.3774,
+      "Y": -216.03796,
+      "Z": -167.19952
     },
     "Rotation": {
       "Pitch": 0,
@@ -14302,7 +14302,7 @@
     "Origin": {
       "X": -1919.2693,
       "Y": 748.9163,
-      "Z": -1024
+      "Z": -45.391968
     },
     "Rotation": {
       "Pitch": 0,
@@ -14354,7 +14354,7 @@
         "Class": "CKnife",
         "Weapon": "weapon_bayonet",
         "PaintKit": {
-          "Name": "default"
+          "Name": "am_doppler_phase3"
         },
         "Quality": "Unusual",
         "Rarity": "Common",
@@ -14444,9 +14444,9 @@
     "Deaths": 17,
     "LastPlaceName": "BombsiteB",
     "Origin": {
-      "X": -2048,
-      "Y": -1024,
-      "Z": -1024
+      "X": -1550.7078,
+      "Y": -174.88373,
+      "Z": -161.92578
     },
     "Rotation": {
       "Pitch": 0,
@@ -14987,7 +14987,7 @@
         "Class": "CAK47",
         "Weapon": "weapon_ak47",
         "PaintKit": {
-          "Name": "cu_ak47_cogthings"
+          "Name": "default"
         },
         "Quality": "Unique",
         "Rarity": "Common",
@@ -15134,9 +15134,9 @@
     "Deaths": 15,
     "LastPlaceName": "BombsiteB",
     "Origin": {
-      "X": -3072,
-      "Y": 0,
-      "Z": -1024
+      "X": -2321.2788,
+      "Y": 432.05084,
+      "Z": -167.96875
     },
     "Rotation": {
       "Pitch": 0,
@@ -15538,7 +15538,7 @@
         "Class": "CAK47",
         "Weapon": "weapon_ak47",
         "PaintKit": {
-          "Name": "cu_ak47_cogthings"
+          "Name": "default"
         },
         "Quality": "Unique",
         "Rarity": "Common",
@@ -15682,7 +15682,7 @@
     "Origin": {
       "X": -500.89966,
       "Y": -2097.0513,
-      "Z": -179.96875
+      "Z": -179.83728
     },
     "Rotation": {
       "Pitch": 0,
@@ -15751,7 +15751,7 @@
     "Origin": {
       "X": 367.96875,
       "Y": -2178.7146,
-      "Z": -1024
+      "Z": -55.96875
     },
     "Rotation": {
       "Pitch": 0,
@@ -15895,7 +15895,7 @@
     },
     "Weapons": []
   }
-[311535] Interval snapshot:
+[311534] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",
@@ -16442,7 +16442,7 @@
         "Class": "CAK47",
         "Weapon": "weapon_ak47",
         "PaintKit": {
-          "Name": "cu_ak47_cogthings"
+          "Name": "default"
         },
         "Quality": "Unique",
         "Rarity": "Common",
@@ -17323,7 +17323,7 @@
         "Class": "CAK47",
         "Weapon": "weapon_ak47",
         "PaintKit": {
-          "Name": "cu_ak47_cogthings"
+          "Name": "default"
         },
         "Quality": "Unique",
         "Rarity": "Common",

--- a/src/DemoFile.Test/Snapshots/Position.txt
+++ b/src/DemoFile.Test/Snapshots/Position.txt
@@ -2954,7 +2954,7 @@
     },
     "Weapons": []
   }
-[157934] Interval snapshot:
+[157935] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",
@@ -3032,13 +3032,13 @@
     "LastPlaceName": "Apartments",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": -1836.4205,
-      "Y": 761.94495,
+      "X": -1834.6072,
+      "Y": 761.71326,
       "Z": -47.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -11.696655,
+      "Yaw": -11.749878,
       "Roll": 0
     },
     "EyeAngles": {
@@ -3244,18 +3244,18 @@
     "LastPlaceName": "Catwalk",
     "ActiveWeapon": "CWeaponGalilAR",
     "Origin": {
-      "X": -992.00696,
-      "Y": -117.87042,
+      "X": -990.98285,
+      "Y": -116.51825,
       "Z": -167.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -37.21756,
+      "Yaw": -37.28279,
       "Roll": 0
     },
     "EyeAngles": {
       "Pitch": 3.0360107,
-      "Yaw": -37.252228,
+      "Yaw": -37.34012,
       "Roll": 0
     },
     "Weapons": [
@@ -3325,18 +3325,18 @@
     "LastPlaceName": "BombsiteA",
     "ActiveWeapon": "CAK47",
     "Origin": {
-      "X": -1004.04236,
-      "Y": -2324.4055,
-      "Z": -167.55713
+      "X": -1007.3092,
+      "Y": -2323.6953,
+      "Z": -163.04382
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 168.38437,
+      "Yaw": 169.51184,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 6.1777496,
-      "Yaw": 173.35535,
+      "Pitch": 5.3063965,
+      "Yaw": 174.82062,
       "Roll": 0
     },
     "Weapons": [
@@ -3441,7 +3441,7 @@
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -168.0201,
+      "Yaw": -168.02112,
       "Roll": 0
     },
     "EyeAngles": {
@@ -3552,8 +3552,8 @@
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 10.120117,
-      "Yaw": -174.17381,
+      "Pitch": 11.329987,
+      "Yaw": -167.46391,
       "Roll": 0
     },
     "Weapons": [
@@ -3639,18 +3639,18 @@
     "LastPlaceName": "Middle",
     "ActiveWeapon": "CWeaponGalilAR",
     "Origin": {
-      "X": -115.2829,
-      "Y": -775.86475,
-      "Z": -215.97913
+      "X": -114.64331,
+      "Y": -775.05,
+      "Z": -215.84283
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 142.2987,
+      "Yaw": 142.23312,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": -0.1980896,
-      "Yaw": 141.85855,
+      "Pitch": -0.1538086,
+      "Yaw": 141.68277,
       "Roll": 0
     },
     "Weapons": [
@@ -6101,7 +6101,7 @@
     },
     "Weapons": []
   }
-[196334] Interval snapshot:
+[196335] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",
@@ -6302,8 +6302,8 @@
     "LastPlaceName": "Shop",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": -2304.964,
-      "Y": -468.00244,
+      "X": -2305.2866,
+      "Y": -466.25098,
       "Z": -167.96875
     },
     "Rotation": {
@@ -6443,18 +6443,18 @@
     "LastPlaceName": "BombsiteA",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": 140.36563,
-      "Y": -1982.4438,
-      "Z": -134.29114
+      "X": 141.79317,
+      "Y": -1981.8328,
+      "Z": -131.51099
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -12.371292,
+      "Yaw": -15.673035,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": -9.147827,
-      "Yaw": -53.091087,
+      "Pitch": -7.9135895,
+      "Yaw": -64.27139,
       "Roll": 0
     },
     "Weapons": [
@@ -6553,13 +6553,13 @@
     "LastPlaceName": "Jungle",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": -1224.6986,
+      "X": -1223.9816,
       "Y": -1526.9688,
-      "Z": -152.49683
+      "Z": -152.56763
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 82.55884,
+      "Yaw": 82.559845,
       "Roll": 0
     },
     "EyeAngles": {
@@ -6710,9 +6710,9 @@
     "LastPlaceName": "SideAlley",
     "ActiveWeapon": "CWeaponAWP",
     "Origin": {
-      "X": 349.91104,
-      "Y": 143.31969,
-      "Z": -241.84888
+      "X": 349.57492,
+      "Y": 141.81766,
+      "Z": -241.30621
     },
     "Rotation": {
       "Pitch": 0,
@@ -6864,18 +6864,18 @@
     "LastPlaceName": "Underpass",
     "ActiveWeapon": "CAK47",
     "Origin": {
-      "X": -1046.7396,
-      "Y": 154.05153,
+      "X": -1046.6476,
+      "Y": 152.36642,
       "Z": -367.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -81.799736,
+      "Yaw": -81.750984,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": -5.037918,
-      "Yaw": -81.76712,
+      "Pitch": -5.0818634,
+      "Yaw": -81.723175,
       "Roll": 0
     },
     "Weapons": [
@@ -8587,7 +8587,7 @@
     },
     "Weapons": []
   }
-[234734] Interval snapshot:
+[234735] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",
@@ -8752,12 +8752,12 @@
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 80.48102,
+      "Yaw": 80.32037,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": -1.8017578,
-      "Yaw": 62.497437,
+      "Pitch": -1.782196,
+      "Yaw": 62.57675,
       "Roll": 0
     },
     "Weapons": [
@@ -8814,13 +8814,13 @@
     "LastPlaceName": "Catwalk",
     "ActiveWeapon": "CWeaponP250",
     "Origin": {
-      "X": -558.94745,
-      "Y": -494.43066,
-      "Z": -166.13165
+      "X": -558.7208,
+      "Y": -494.31268,
+      "Z": -166.13098
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 117.513885,
+      "Yaw": 117.5101,
       "Roll": 0
     },
     "EyeAngles": {
@@ -8883,7 +8883,7 @@
     "ActiveWeapon": "CWeaponGlock",
     "Origin": {
       "X": -1247.9696,
-      "Y": -563.4946,
+      "Y": -562.28766,
       "Z": -167.96875
     },
     "Rotation": {
@@ -8950,18 +8950,18 @@
     "LastPlaceName": "Connector",
     "ActiveWeapon": "CWeaponGlock",
     "Origin": {
-      "X": -781.2559,
-      "Y": -1023.2875,
+      "X": -780.4675,
+      "Y": -1022.99225,
       "Z": -167.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -69.42982,
+      "Yaw": -69.4796,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 0.17611694,
-      "Yaw": -69.46449,
+      "Pitch": 0.13183594,
+      "Yaw": -69.50844,
       "Roll": 0
     },
     "Weapons": [
@@ -9167,8 +9167,8 @@
     "LastPlaceName": "BombsiteB",
     "ActiveWeapon": "CWeaponElite",
     "Origin": {
-      "X": -2021.8165,
-      "Y": 363.94922,
+      "X": -2021.277,
+      "Y": 366.3002,
       "Z": -159.96875
     },
     "Rotation": {
@@ -9300,8 +9300,8 @@
     "LastPlaceName": "PalaceInterior",
     "ActiveWeapon": "CWeaponElite",
     "Origin": {
-      "X": 365.13593,
-      "Y": -1944.0347,
+      "X": 365.1959,
+      "Y": -1944.0397,
       "Z": -39.96875
     },
     "Rotation": {
@@ -11904,7 +11904,7 @@
     },
     "Weapons": []
   }
-[273134] Interval snapshot:
+[273135] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",
@@ -11982,9 +11982,9 @@
     "LastPlaceName": "TopofMid",
     "ActiveWeapon": "CAK47",
     "Origin": {
-      "X": 503.20663,
-      "Y": -454.9369,
-      "Z": -159.99426
+      "X": 503.26428,
+      "Y": -456.07764,
+      "Z": -159.99243
     },
     "Rotation": {
       "Pitch": 0,
@@ -12098,12 +12098,12 @@
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 144.89801,
+      "Yaw": 144.62952,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 1.4453888,
-      "Yaw": 138.74738,
+      "Pitch": 1.5047913,
+      "Yaw": 143.28162,
       "Roll": 0
     },
     "Weapons": [
@@ -12215,8 +12215,8 @@
     "LastPlaceName": "Underpass",
     "ActiveWeapon": "CWeaponGalilAR",
     "Origin": {
-      "X": -931.2329,
-      "Y": 466.15787,
+      "X": -930.26447,
+      "Y": 465.84125,
       "Z": -367.96875
     },
     "Rotation": {
@@ -12318,12 +12318,12 @@
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 52.29698,
+      "Yaw": 52.321014,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 1.125412,
-      "Yaw": 52.360504,
+      "Pitch": 1.0890198,
+      "Yaw": 52.324097,
       "Roll": 0
     },
     "Weapons": [
@@ -12409,18 +12409,18 @@
     "LastPlaceName": "BackAlley",
     "ActiveWeapon": "CWeaponGalilAR",
     "Origin": {
-      "X": -916.6452,
-      "Y": 565.0045,
-      "Z": -81.75012
+      "X": -916.93756,
+      "Y": 564.013,
+      "Z": -81.74481
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 163.56342,
+      "Yaw": 163.49545,
       "Roll": 0
     },
     "EyeAngles": {
       "Pitch": -2.4640198,
-      "Yaw": 163.51913,
+      "Yaw": 163.43124,
       "Roll": 0
     },
     "Weapons": [
@@ -12506,13 +12506,13 @@
     "LastPlaceName": "BombsiteA",
     "ActiveWeapon": "CWeaponMP9",
     "Origin": {
-      "X": 122.3635,
-      "Y": -1709.9886,
+      "X": 122.0562,
+      "Y": -1709.7021,
       "Z": -167.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 59.263687,
+      "Yaw": 59.334076,
       "Roll": 0
     },
     "EyeAngles": {
@@ -12624,9 +12624,9 @@
     "LastPlaceName": "BombsiteB",
     "ActiveWeapon": "CKnife",
     "Origin": {
-      "X": -2170.393,
-      "Y": 556.03186,
-      "Z": -159.68604
+      "X": -2170.4429,
+      "Y": 557.53174,
+      "Z": -159.32507
     },
     "Rotation": {
       "Pitch": 0,
@@ -12705,18 +12705,18 @@
     "LastPlaceName": "Middle",
     "ActiveWeapon": "CWeaponM4A1",
     "Origin": {
-      "X": -965.8047,
-      "Y": -579.0725,
-      "Z": -275.27313
+      "X": -964.36786,
+      "Y": -580.2028,
+      "Z": -274.47235
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": 7.2767334,
+      "Yaw": 7.256134,
       "Roll": 0
     },
     "EyeAngles": {
       "Pitch": -2.090149,
-      "Yaw": 7.2767334,
+      "Yaw": 7.25441,
       "Roll": 0
     },
     "Weapons": [
@@ -12815,18 +12815,18 @@
     "LastPlaceName": "Underpass",
     "ActiveWeapon": "CFlashbang",
     "Origin": {
-      "X": -1068.36,
-      "Y": -423.16412,
+      "X": -1067.7012,
+      "Y": -424.48157,
       "Z": -263.96875
     },
     "Rotation": {
       "Pitch": 0,
-      "Yaw": -10.508759,
+      "Yaw": -11.196106,
       "Roll": 0
     },
     "EyeAngles": {
-      "Pitch": 4.5936584,
-      "Yaw": -18.658905,
+      "Pitch": 4.505432,
+      "Yaw": -20.559875,
       "Roll": 0
     },
     "Weapons": [
@@ -15895,7 +15895,7 @@
     },
     "Weapons": []
   }
-[311534] Interval snapshot:
+[311535] Interval snapshot:
   {
     "IsActive": true,
     "PlayerName": "ESL GOTV",

--- a/src/DemoFile/DemoParser.Entities.cs
+++ b/src/DemoFile/DemoParser.Entities.cs
@@ -124,7 +124,7 @@ public partial class DemoParser
     private void OnServerInfo(CSVCMsg_ServerInfo msg)
     {
         Debug.Assert(_playerInfos[msg.PlayerSlot] != null);
-        IsGotvRecording = _playerInfos[msg.PlayerSlot]?.Ishltv ?? false;
+        IsGotv = _playerInfos[msg.PlayerSlot]?.Ishltv ?? false;
         _fullSnapshotRead = false;
 
         MaxPlayers = msg.MaxClients;
@@ -260,7 +260,7 @@ public partial class DemoParser
         // Clear out all entities - this is a full update.
         if (!msg.IsDelta)
         {
-            if (IsGotvRecording)
+            if (IsGotv)
             {
                 // In GOTV recordings, we see a snapshot every 3840 ticks (60 seconds).
                 // After we've read the first one, we can ignore the rest.

--- a/src/DemoFile/DemoParser.cs
+++ b/src/DemoFile/DemoParser.cs
@@ -14,10 +14,10 @@ public sealed partial class DemoParser
     private readonly PriorityQueue<ITickTimer, uint> _serverTickTimers = new();
     private readonly Source1GameEvents _source1GameEvents = new();
     private DemoEvents _demoEvents;
+    private EntityEvents _entityEvents;
     private GameEvents _gameEvents;
     private PacketEvents _packetEvents;
     private UserMessageEvents _userMessageEvents;
-    private EntityEvents _entityEvents;
 
     public Action<DemoProgressEvent>? OnProgress;
 
@@ -58,6 +58,11 @@ public sealed partial class DemoParser
     public TimeSpan Elapsed => TimeSpan.FromSeconds(Math.Max(0, CurrentDemoTick.Value) / 64.0f);
 
     public CSVCMsg_ServerInfo ServerInfo { get; private set; } = new();
+
+    /// <summary>
+    /// <c>true</c> if the recording client is GOTV. <c>false</c> if this is a POV demo.
+    /// </summary>
+    public bool IsGotvRecording { get; private set; }
 
     private void OnDemoPacket(CDemoPacket msg)
     {

--- a/src/DemoFile/DemoParser.cs
+++ b/src/DemoFile/DemoParser.cs
@@ -62,7 +62,7 @@ public sealed partial class DemoParser
     /// <summary>
     /// <c>true</c> if the recording client is GOTV. <c>false</c> if this is a POV demo.
     /// </summary>
-    public bool IsGotvRecording { get; private set; }
+    public bool IsGotv { get; private set; }
 
     private void OnDemoPacket(CDemoPacket msg)
     {

--- a/src/DemoFile/FieldDecode.cs
+++ b/src/DemoFile/FieldDecode.cs
@@ -12,6 +12,8 @@ internal static class FieldDecode
 
     public delegate T FieldDecoder<T>(ref BitBuffer buffer);
 
+    public delegate TValue CustomDeserializer<TType, TValue>(TType @this, ref BitBuffer buffer);
+
     public static FieldDecoder<T> CreateDecoder_enum<T>(
         FieldEncodingInfo fieldEncodingInfo)
         where T : struct

--- a/src/DemoFile/Model/DemoTick.cs
+++ b/src/DemoFile/Model/DemoTick.cs
@@ -10,6 +10,9 @@ namespace DemoFile;
 /// <seealso cref="GameTick"/>
 public readonly record struct DemoTick(int Value) : IComparable<DemoTick>
 {
+    public static readonly DemoTick Zero = default;
+    public static readonly DemoTick PreRecord = new(-1);
+
     public int CompareTo(DemoTick other) => Value.CompareTo(other.Value);
 
     public override string ToString() => Value == -1 ? "<pre record>" : $"Demo tick {Value}";

--- a/src/DemoFile/Sdk/CBaseEntity.Decoder.cs
+++ b/src/DemoFile/Sdk/CBaseEntity.Decoder.cs
@@ -2,19 +2,22 @@
 
 public partial class CBaseEntity
 {
-    private static FieldDecode.FieldDecoder<float> CreateDecoder_animTimeSerializer(
+    private static FieldDecode.CustomDeserializer<CBaseEntity, float> CreateDecoder_animTimeSerializer(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return (ref BitBuffer buffer) => FieldDecode.DecodeSimulationTime(ref buffer);
+        return (CBaseEntity _, ref BitBuffer buffer) => FieldDecode.DecodeSimulationTime(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<float> CreateDecoder_simulationTimeSerializer(
+    private static FieldDecode.CustomDeserializer<CBaseEntity, float> CreateDecoder_simulationTimeSerializer(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return (ref BitBuffer buffer) => FieldDecode.DecodeSimulationTime(ref buffer);
+        return (CBaseEntity _, ref BitBuffer buffer) => FieldDecode.DecodeSimulationTime(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<int> CreateDecoder_ClampHealth(
-        FieldEncodingInfo fieldEncodingInfo) =>
-        FieldDecode.CreateDecoder_Int32(fieldEncodingInfo);
+    private static FieldDecode.CustomDeserializer<CBaseEntity, int> CreateDecoder_ClampHealth(
+        FieldEncodingInfo fieldEncodingInfo)
+    {
+        var decoder = FieldDecode.CreateDecoder_Int32(fieldEncodingInfo);
+        return (CBaseEntity _, ref BitBuffer buffer) => decoder(ref buffer);
+    }
 }

--- a/src/DemoFile/Sdk/CBasePlayerWeapon.Decoder.cs
+++ b/src/DemoFile/Sdk/CBasePlayerWeapon.Decoder.cs
@@ -2,9 +2,9 @@
 
 public partial class CBasePlayerWeapon
 {
-    private static FieldDecode.FieldDecoder<int> CreateDecoder_minusone(
+    private static FieldDecode.CustomDeserializer<CBasePlayerWeapon, int> CreateDecoder_minusone(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return (ref BitBuffer buffer) => (int)buffer.ReadUVarInt32() - 1;
+        return (CBasePlayerWeapon _, ref BitBuffer buffer) => (int)buffer.ReadUVarInt32() - 1;
     }
 }

--- a/src/DemoFile/Sdk/CFish.Decoder.cs
+++ b/src/DemoFile/Sdk/CFish.Decoder.cs
@@ -2,32 +2,31 @@
 
 public partial class CFish
 {
-    private static FieldDecode.FieldDecoder<float> CreateDecoder_fish_pos_x(
+    private static FieldDecode.CustomDeserializer<CFish, float> CreateDecoder_fish_pos_x(
         FieldEncodingInfo fieldEncodingInfo)
     {
         // Offset relative to m_poolOrigin
-        return (ref BitBuffer buffer) => FieldDecode.DecodeFloatNoscale(ref buffer);
+        return (CFish _, ref BitBuffer buffer) => FieldDecode.DecodeFloatNoscale(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<float> CreateDecoder_fish_pos_y(
+    private static FieldDecode.CustomDeserializer<CFish, float> CreateDecoder_fish_pos_y(
         FieldEncodingInfo fieldEncodingInfo)
     {
         // Offset relative to m_poolOrigin
-        return (ref BitBuffer buffer) => FieldDecode.DecodeFloatNoscale(ref buffer);
+        return (CFish _, ref BitBuffer buffer) => FieldDecode.DecodeFloatNoscale(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<float> CreateDecoder_fish_pos_z(
+    private static FieldDecode.CustomDeserializer<CFish, float> CreateDecoder_fish_pos_z(
         FieldEncodingInfo fieldEncodingInfo)
     {
         // Offset relative to m_poolOrigin
-        return (ref BitBuffer buffer) => FieldDecode.DecodeFloatNoscale(ref buffer);
+        return (CFish _, ref BitBuffer buffer) => FieldDecode.DecodeFloatNoscale(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<float> CreateDecoder_angle_normalize_positive(
+    private static FieldDecode.CustomDeserializer<CFish, float> CreateDecoder_angle_normalize_positive(
         FieldEncodingInfo fieldEncodingInfo)
     {
         // Angle in the range of [0..360]
-        return (ref BitBuffer buffer) => FieldDecode.DecodeFloatNoscale(ref buffer);
+        return (CFish _, ref BitBuffer buffer) => FieldDecode.DecodeFloatNoscale(ref buffer);
     }
-
 }

--- a/src/DemoFile/Sdk/CGameSceneNode.Decoder.cs
+++ b/src/DemoFile/Sdk/CGameSceneNode.Decoder.cs
@@ -2,15 +2,16 @@
 
 public partial class CGameSceneNode
 {
-    private static FieldDecode.FieldDecoder<QAngle> CreateDecoder_gameSceneNodeStepSimulationAnglesSerializer(
+    private static FieldDecode.CustomDeserializer<CGameSceneNode, QAngle> CreateDecoder_gameSceneNodeStepSimulationAnglesSerializer(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return FieldDecode.CreateDecoder_QAngle(fieldEncodingInfo);
+        var decoder = FieldDecode.CreateDecoder_QAngle(fieldEncodingInfo);
+        return (CGameSceneNode _, ref BitBuffer buffer) => decoder(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<CGameSceneNodeHandle> CreateDecoder_gameSceneNode(
+    private static FieldDecode.CustomDeserializer<CGameSceneNode, CGameSceneNodeHandle> CreateDecoder_gameSceneNode(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return (ref BitBuffer buffer) => new CGameSceneNodeHandle(buffer.ReadUVarInt32());
+        return (CGameSceneNode _, ref BitBuffer buffer) => new CGameSceneNodeHandle(buffer.ReadUVarInt32());
     }
 }

--- a/src/DemoFile/Sdk/CNetworkOriginCellCoordQuantizedVector.cs
+++ b/src/DemoFile/Sdk/CNetworkOriginCellCoordQuantizedVector.cs
@@ -1,6 +1,6 @@
 ﻿namespace DemoFile.Sdk;
 
-public partial class CNetworkOriginCellCoordQuantizedVector
+public sealed partial class CNetworkOriginCellCoordQuantizedVector : IEquatable<CNetworkOriginCellCoordQuantizedVector>
 {
     private const int CELL_WIDTH = 1 << 9;
 
@@ -9,39 +9,105 @@ public partial class CNetworkOriginCellCoordQuantizedVector
         (CellY - 32) * CELL_WIDTH + Y,
         (CellZ - 32) * CELL_WIDTH + Z);
 
-    private static FieldDecode.FieldDecoder<UInt16> CreateDecoder_cellx(
-        FieldEncodingInfo fieldEncodingInfo)
+    public bool Equals(CNetworkOriginCellCoordQuantizedVector? other)
     {
-        return FieldDecode.CreateDecoder_UInt16(fieldEncodingInfo);
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Vector.Equals(other.Vector);
     }
 
-    private static FieldDecode.FieldDecoder<UInt16> CreateDecoder_celly(
+    public override string ToString() => Vector.ToString();
+
+    private static FieldDecode.CustomDeserializer<CNetworkOriginCellCoordQuantizedVector, UInt16> CreateDecoder_cellx(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return FieldDecode.CreateDecoder_UInt16(fieldEncodingInfo);
+        var decoder = FieldDecode.CreateDecoder_UInt16(fieldEncodingInfo);
+        return (CNetworkOriginCellCoordQuantizedVector _, ref BitBuffer buffer) => decoder(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<UInt16> CreateDecoder_cellz(
+    private static FieldDecode.CustomDeserializer<CNetworkOriginCellCoordQuantizedVector, UInt16> CreateDecoder_celly(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return FieldDecode.CreateDecoder_UInt16(fieldEncodingInfo);
+        var decoder = FieldDecode.CreateDecoder_UInt16(fieldEncodingInfo);
+        return (CNetworkOriginCellCoordQuantizedVector _, ref BitBuffer buffer) => decoder(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<float> CreateDecoder_posx(
+    private static FieldDecode.CustomDeserializer<CNetworkOriginCellCoordQuantizedVector, UInt16> CreateDecoder_cellz(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return FieldDecode.CreateDecoder_float(fieldEncodingInfo);
+        var decoder = FieldDecode.CreateDecoder_UInt16(fieldEncodingInfo);
+        return (CNetworkOriginCellCoordQuantizedVector _, ref BitBuffer buffer) => decoder(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<float> CreateDecoder_posy(
+    private static FieldDecode.CustomDeserializer<CNetworkOriginCellCoordQuantizedVector, float> CreateDecoder_posx(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return FieldDecode.CreateDecoder_float(fieldEncodingInfo);
+        var decoder = FieldDecode.CreateDecoder_float(fieldEncodingInfo);
+
+        // Player pawns have m_vecX, m_vecY and m_vecZ overridden to be 32-bit floats,
+        // instead of the usual 15-bit quantized floats.
+        // Occasionally we see one or more of these fields encoded as all zeros.
+        // Ignore these to avoid pawn positions jittering.
+        // See https://github.com/saul/demofile-net/issues/27
+        if (fieldEncodingInfo.BitCount == 32)
+        {
+            return (CNetworkOriginCellCoordQuantizedVector @this, ref BitBuffer buffer) =>
+            {
+                var result = decoder(ref buffer);
+                return result == default ? @this.X : result;
+            };
+        }
+
+        return (CNetworkOriginCellCoordQuantizedVector _, ref BitBuffer buffer) => decoder(ref buffer);
     }
 
-    private static FieldDecode.FieldDecoder<float> CreateDecoder_posz(
+    private static FieldDecode.CustomDeserializer<CNetworkOriginCellCoordQuantizedVector, float> CreateDecoder_posy(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return FieldDecode.CreateDecoder_float(fieldEncodingInfo);
+        var decoder = FieldDecode.CreateDecoder_float(fieldEncodingInfo);
+
+        if (fieldEncodingInfo.BitCount == 32)
+        {
+            return (CNetworkOriginCellCoordQuantizedVector @this, ref BitBuffer buffer) =>
+            {
+                var result = decoder(ref buffer);
+                return result == default ? @this.Y : result;
+            };
+        }
+
+        return (CNetworkOriginCellCoordQuantizedVector _, ref BitBuffer buffer) => decoder(ref buffer);
     }
+
+    private static FieldDecode.CustomDeserializer<CNetworkOriginCellCoordQuantizedVector, float> CreateDecoder_posz(
+        FieldEncodingInfo fieldEncodingInfo)
+    {
+        var decoder = FieldDecode.CreateDecoder_float(fieldEncodingInfo);
+
+        // Realistically Z pos could actually be 0, but this is
+        // the best we can do to avoid jittering positions.
+        if (fieldEncodingInfo.BitCount == 32)
+        {
+            return (CNetworkOriginCellCoordQuantizedVector @this, ref BitBuffer buffer) =>
+            {
+                var result = decoder(ref buffer);
+                return result == default ? @this.Z : result;
+            };
+        }
+
+        return (CNetworkOriginCellCoordQuantizedVector _, ref BitBuffer buffer) => decoder(ref buffer);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+        return Equals((CNetworkOriginCellCoordQuantizedVector) obj);
+    }
+
+    public override int GetHashCode() => Vector.GetHashCode();
+
+    public static bool operator ==(CNetworkOriginCellCoordQuantizedVector? left, CNetworkOriginCellCoordQuantizedVector? right) => Equals(left, right);
+
+    public static bool operator !=(CNetworkOriginCellCoordQuantizedVector? left, CNetworkOriginCellCoordQuantizedVector? right) => !Equals(left, right);
 }

--- a/src/DemoFile/Sdk/CNetworkedSequenceOperation.Decoder.cs
+++ b/src/DemoFile/Sdk/CNetworkedSequenceOperation.Decoder.cs
@@ -2,10 +2,10 @@
 
 public partial class CNetworkedSequenceOperation
 {
-    private static FieldDecode.FieldDecoder<HSequence> CreateDecoder_minusone(
+    private static FieldDecode.CustomDeserializer<CNetworkedSequenceOperation, HSequence> CreateDecoder_minusone(
         FieldEncodingInfo fieldEncodingInfo)
     {
-        return (ref BitBuffer buffer) =>
+        return (CNetworkedSequenceOperation _, ref BitBuffer buffer) =>
         {
             var read = buffer.ReadUVarInt64() - 1;
             return new HSequence((long)read);

--- a/src/DemoFile/Sdk/DecoderSet.cs
+++ b/src/DemoFile/Sdk/DecoderSet.cs
@@ -56,7 +56,8 @@ internal partial class DecoderSet
             var _serializer = serializer;
 #endif
 
-            fieldDecodersByIndex[path[0]](instance, path, ref buffer);
+            var fieldDecoder = fieldDecodersByIndex[path[0]];
+            fieldDecoder(instance, path, ref buffer);
         };
     }
 }

--- a/src/DemoFile/Sdk/Schema.cs
+++ b/src/DemoFile/Sdk/Schema.cs
@@ -2710,7 +2710,7 @@ public partial class CBaseEntity : CEntityInstance
             var decoder = CreateDecoder_ClampHealth(field.FieldEncodingInfo);
             return (CBaseEntity @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Health = decoder(ref buffer);
+                @this.Health = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_iMaxHealth")
@@ -2774,7 +2774,7 @@ public partial class CBaseEntity : CEntityInstance
             var decoder = CreateDecoder_animTimeSerializer(field.FieldEncodingInfo);
             return (CBaseEntity @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.AnimTime = decoder(ref buffer);
+                @this.AnimTime = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_flSimulationTime")
@@ -2782,7 +2782,7 @@ public partial class CBaseEntity : CEntityInstance
             var decoder = CreateDecoder_simulationTimeSerializer(field.FieldEncodingInfo);
             return (CBaseEntity @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.SimulationTime = decoder(ref buffer);
+                @this.SimulationTime = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_flCreateTime")
@@ -4047,7 +4047,7 @@ public partial class CBasePlayerWeapon : CEconEntity
             var decoder = CreateDecoder_minusone(field.FieldEncodingInfo);
             return (CBasePlayerWeapon @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Clip1 = decoder(ref buffer);
+                @this.Clip1 = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_iClip2")
@@ -4055,7 +4055,7 @@ public partial class CBasePlayerWeapon : CEconEntity
             var decoder = CreateDecoder_minusone(field.FieldEncodingInfo);
             return (CBasePlayerWeapon @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Clip2 = decoder(ref buffer);
+                @this.Clip2 = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_pReserveAmmo")
@@ -14285,7 +14285,7 @@ public partial class CFish : CBaseAnimGraph
             var decoder = CreateDecoder_fish_pos_x(field.FieldEncodingInfo);
             return (CFish @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.X = decoder(ref buffer);
+                @this.X = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_y")
@@ -14293,7 +14293,7 @@ public partial class CFish : CBaseAnimGraph
             var decoder = CreateDecoder_fish_pos_y(field.FieldEncodingInfo);
             return (CFish @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Y = decoder(ref buffer);
+                @this.Y = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_z")
@@ -14301,7 +14301,7 @@ public partial class CFish : CBaseAnimGraph
             var decoder = CreateDecoder_fish_pos_z(field.FieldEncodingInfo);
             return (CFish @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Z = decoder(ref buffer);
+                @this.Z = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_angle")
@@ -14309,7 +14309,7 @@ public partial class CFish : CBaseAnimGraph
             var decoder = CreateDecoder_angle_normalize_positive(field.FieldEncodingInfo);
             return (CFish @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Angle = decoder(ref buffer);
+                @this.Angle = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_poolOrigin")
@@ -15223,7 +15223,7 @@ public partial class CGameSceneNode
             var decoder = CreateDecoder_gameSceneNode(field.FieldEncodingInfo);
             return (CGameSceneNode @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Parent = decoder(ref buffer);
+                @this.Parent = decoder(@this, ref buffer);
             };
         }
         if (field.SendNode.Length >= 1 && field.SendNode.Span[0] == "m_vecOrigin")
@@ -15239,7 +15239,7 @@ public partial class CGameSceneNode
             var decoder = CreateDecoder_gameSceneNodeStepSimulationAnglesSerializer(field.FieldEncodingInfo);
             return (CGameSceneNode @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Rotation = decoder(ref buffer);
+                @this.Rotation = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_flScale")
@@ -18240,7 +18240,7 @@ public partial class CNetworkedSequenceOperation
             var decoder = CreateDecoder_minusone(field.FieldEncodingInfo);
             return (CNetworkedSequenceOperation @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Sequence = decoder(ref buffer);
+                @this.Sequence = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_flPrevCycle")
@@ -18335,7 +18335,7 @@ public partial class CNetworkOriginCellCoordQuantizedVector
             var decoder = CreateDecoder_cellx(field.FieldEncodingInfo);
             return (CNetworkOriginCellCoordQuantizedVector @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.CellX = decoder(ref buffer);
+                @this.CellX = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_cellY")
@@ -18343,7 +18343,7 @@ public partial class CNetworkOriginCellCoordQuantizedVector
             var decoder = CreateDecoder_celly(field.FieldEncodingInfo);
             return (CNetworkOriginCellCoordQuantizedVector @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.CellY = decoder(ref buffer);
+                @this.CellY = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_cellZ")
@@ -18351,7 +18351,7 @@ public partial class CNetworkOriginCellCoordQuantizedVector
             var decoder = CreateDecoder_cellz(field.FieldEncodingInfo);
             return (CNetworkOriginCellCoordQuantizedVector @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.CellZ = decoder(ref buffer);
+                @this.CellZ = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_nOutsideWorld")
@@ -18367,7 +18367,7 @@ public partial class CNetworkOriginCellCoordQuantizedVector
             var decoder = CreateDecoder_posx(field.FieldEncodingInfo);
             return (CNetworkOriginCellCoordQuantizedVector @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.X = decoder(ref buffer);
+                @this.X = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_vecY")
@@ -18375,7 +18375,7 @@ public partial class CNetworkOriginCellCoordQuantizedVector
             var decoder = CreateDecoder_posy(field.FieldEncodingInfo);
             return (CNetworkOriginCellCoordQuantizedVector @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Y = decoder(ref buffer);
+                @this.Y = decoder(@this, ref buffer);
             };
         }
         if (field.VarName == "m_vecZ")
@@ -18383,7 +18383,7 @@ public partial class CNetworkOriginCellCoordQuantizedVector
             var decoder = CreateDecoder_posz(field.FieldEncodingInfo);
             return (CNetworkOriginCellCoordQuantizedVector @this, ReadOnlySpan<int> path, ref BitBuffer buffer) =>
             {
-                @this.Z = decoder(ref buffer);
+                @this.Z = decoder(@this, ref buffer);
             };
         }
         if (FallbackDecoder.TryCreate(field.VarName, field.VarType, field.FieldEncodingInfo, decoderSet, out var fallback))

--- a/src/DemoFile/version.json
+++ b/src/DemoFile/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Position jittering fixed by skipping over m_vecX/Y/Z that are entirely 0 bits (i.e. `default(float)`). Fixes #27 

Improves GOTV parsing time by ~10%

| Method    | Job        | Arguments        | Mean    | Error    | StdDev   | Ratio | Gen0        | Gen1       | Gen2      | Allocated | Alloc Ratio |
|---------- |----------- |----------------- |--------:|---------:|---------:|------:|------------:|-----------:|----------:|----------:|------------:|
| ParseDemo | Job-IQMOBV | /p:Baseline=true | 1.513 s | 0.0094 s | 0.0079 s |  1.00 | 104000.0000 | 19000.0000 | 9000.0000 | 703.21 MB |        1.00 |
| ParseDemo | Job-TKWDSX | Default          | 1.373 s | 0.0216 s | 0.0202 s |  0.90 |  84000.0000 |  4000.0000 | 2000.0000 |  603.5 MB |        0.86 |
