### PR TITLE
Add multi-threaded parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ bin/
 /GameTracking-CSGO/
 *.dem
 .idea/
+.vs/
 *.DotSettings.user

--- a/src/DemoFile.Benchmark/DemoParserBenchmark.cs
+++ b/src/DemoFile.Benchmark/DemoParserBenchmark.cs
@@ -35,7 +35,7 @@ public class DemoParserBenchmark
     [IterationSetup]
     public void Setup()
     {
-        _fileStream = new MemoryStream(_demoBytes);
+        _fileStream = new MemoryStream(_demoBytes, 0, _demoBytes.Length, false, true);
     }
 
     [Benchmark]
@@ -47,5 +47,11 @@ public class DemoParserBenchmark
 #else
         await _demoParser.ReadAllAsync(_fileStream, default);
 #endif
+    }
+
+    [Benchmark]
+    public async Task ParseDemoMT()
+    {
+        await DemoParser.ReadAllMultiThreadedAsync(null, _fileStream, default);
     }
 }

--- a/src/DemoFile.Test/GlobalUtil.cs
+++ b/src/DemoFile.Test/GlobalUtil.cs
@@ -22,6 +22,15 @@ public static class GlobalUtil
 
     public static MemoryStream GotvProtocol13990Deathmatch => new(File.ReadAllBytes(Path.Combine(DemoBase, "13990_dm.dem")));
 
+    public static KeyValuePair<string, MemoryStream>[] GetAllFiles()
+    {
+        return typeof(GlobalUtil)
+            .GetProperties()
+            .Where(p => p.PropertyType == typeof(MemoryStream))
+            .Select(p => new KeyValuePair<string, MemoryStream>(p.Name, (MemoryStream)p.GetValue(null)!))
+            .ToArray();
+    }
+
     public static byte[] ToBitStream(string input)
     {
         var bitArray = new BitArray(input.Length);

--- a/src/DemoFile.Test/Integration/MultiThreadingIntegrationTest.cs
+++ b/src/DemoFile.Test/Integration/MultiThreadingIntegrationTest.cs
@@ -1,0 +1,72 @@
+﻿using System.Text;
+using System.Text.Json;
+
+namespace DemoFile.Test.Integration;
+
+[TestFixture]
+public class MultiThreadingIntegrationTest
+{
+    [TestCaseSource(typeof(GlobalUtil), nameof(GetAllFiles))]
+    public async Task MTTest(KeyValuePair<string, MemoryStream> testCase)
+    {
+        byte[] buffer = testCase.Value.ToArray();
+        var stream = new MemoryStream(buffer, 0, buffer.Length, false, true);
+
+        // MT parsing
+        var mtResult = await DemoParser.ReadAllMultiThreadedAsync(SetupParser, stream, default);
+
+        var mtSB = new StringBuilder(mtResult.Sections.Sum(s => s.StringBuilder.Length));
+        foreach (var section in mtResult.Sections)
+            mtSB.Append(section.StringBuilder);
+
+        // ST parsing
+        var stParser = new DemoParser();
+        var stSection = new MultiThreadedDemoParserSection(stParser);
+        SetupParser(stSection);
+        stream.Position = 0;
+        await stParser.ReadAllAsync(stream, default);
+
+        // compare
+        Assert.That(stSection.StringBuilder.ToString(), Is.EqualTo(mtSB.ToString()));
+    }
+
+    void SetupParser(MultiThreadedDemoParserSection section)
+    {
+        var demo = section.DemoParser;
+        var snapshot = section.StringBuilder;
+        snapshot.EnsureCapacity(512);
+
+        demo.Source1GameEvents.RoundStart += e => LogEvent(e.GameEventName, e, snapshot, demo);
+        demo.Source1GameEvents.RoundEnd += e => LogEvent(e.GameEventName, e, snapshot, demo);
+        demo.Source1GameEvents.PlayerDeath += e => LogEvent(e.GameEventName, e, snapshot, demo);
+
+        // entity access
+        demo.Source1GameEvents.PlayerDeath += e =>
+        {
+            JsonAppend(e.Attacker, snapshot);
+            JsonAppend(e.AttackerPawn, snapshot);
+            JsonAppend(e.Assister, snapshot);
+            JsonAppend(e.AssisterPawn, snapshot);
+            JsonAppend(e.Player, snapshot);
+            JsonAppend(e.PlayerPawn, snapshot);
+
+            snapshot.AppendLine($"{e.Attacker?.PlayerName} [{e.Assister?.PlayerName}] {e.Player?.PlayerName}");
+        };
+    }
+
+    static void JsonAppend(object? obj, StringBuilder stringBuilder)
+    {
+        if (obj == null)
+            return;
+        var str = JsonSerializer.Serialize(obj, DemoJson.SerializerOptions);
+        stringBuilder.AppendLine(str);
+    }
+
+    static void LogEvent<T>(string eventName, T evt, StringBuilder snapshot, DemoParser demo)
+    {
+        snapshot.AppendLine($"[{demo.CurrentDemoTick.Value}] {eventName}:");
+
+        var eventJson = JsonSerializer.Serialize(evt, DemoJson.SerializerOptions);
+        snapshot.AppendLine($"  {eventJson}");
+    }
+}

--- a/src/DemoFile/DemoParser.MultiThreading.cs
+++ b/src/DemoFile/DemoParser.MultiThreading.cs
@@ -1,0 +1,202 @@
+﻿using System.Diagnostics;
+using System.Text;
+
+namespace DemoFile
+{
+    public class MultiThreadedDemoParsingResult
+    {
+        public List<MultiThreadedDemoParserSection> Sections = new();
+
+        internal MultiThreadedDemoParsingResult(params MultiThreadedDemoParserSection[] sections)
+        {
+            Sections.AddRange(sections);
+        }
+    }
+
+    public class MultiThreadedDemoParserSection
+    {
+        public DemoParser DemoParser { get; set; }
+
+        public StringBuilder StringBuilder { get; set; } = new StringBuilder();
+
+        public object? UserData { get; set; }
+
+        public MultiThreadedDemoParserSection(DemoParser demoParser)
+        {
+            DemoParser = demoParser;
+        }
+    }
+
+    public partial class DemoParser
+    {
+        public static async ValueTask<MultiThreadedDemoParsingResult> ReadAllMultiThreadedAsync(
+            Action<MultiThreadedDemoParserSection>? setupAction, MemoryStream stream, CancellationToken cancellationToken)
+        {
+            if (!stream.TryGetBuffer(out var arraySegment))
+                throw new ArgumentException("Can't get buffer");
+
+            var parser = new DemoParser();
+
+            await parser.StartReadingAsync(stream, cancellationToken).ConfigureAwait(false);
+
+            // currently, no way to find snapshot positions in incomplete demos
+            // => fallback to single-threaded parsing
+            if (parser.TickCount.Value <= 0)
+            {
+                stream.Position = 0;
+                parser = new DemoParser();
+                var section = new MultiThreadedDemoParserSection(parser);
+                setupAction?.Invoke(section);
+                await parser.ReadAllAsync(stream, cancellationToken).ConfigureAwait(false);
+                return new MultiThreadedDemoParsingResult(section);
+            }
+
+            int numParsers = 6 * 2;
+            int numSections = (int)Math.Ceiling(parser.TickCount.Value / (double)FullPacketInterval);
+            int numSectionsPerParser = (int)Math.Ceiling(numSections / (double)numParsers);
+            //Console.WriteLine($"num parsers {numParsers}, num sections {numSections}, numSectionsPerParser {numSectionsPerParser}");
+
+            var sw = Stopwatch.StartNew();
+
+            // seek to end of demo to find all snapshot positions
+            await parser.SeekToTickAsync(parser.TickCount, cancellationToken).ConfigureAwait(false);
+
+            //Console.WriteLine($"Seek to end in {sw.ElapsedMilliseconds} ms");
+
+            var tasks = new List<Task>();
+            var threads = new List<Thread>();
+            var sections = new List<MultiThreadedDemoParserSection>();
+
+            for (int p = 0; p < numParsers; p++)
+            {
+                int startFullPacketPositionIndex = p * numSectionsPerParser;
+                int endFullPacketPositionIndex = startFullPacketPositionIndex + numSectionsPerParser;
+
+                //Console.WriteLine($"starting parser {p}, startFullPacketPositionIndex {startFullPacketPositionIndex}, endFullPacketPositionIndex {endFullPacketPositionIndex}");
+
+                bool reachedLastTick = endFullPacketPositionIndex >= parser._fullPacketPositions.Count;
+
+                DemoTick startTick = parser._fullPacketPositions[startFullPacketPositionIndex].Tick;
+                DemoTick endTick = reachedLastTick
+                    ? parser.TickCount
+                    : parser._fullPacketPositions[endFullPacketPositionIndex].Tick;
+
+                var backgroundParser = new DemoParser();
+                var backgroundParserStream = new MemoryStream(arraySegment.Array!);
+                var section = new MultiThreadedDemoParserSection(backgroundParser);
+
+                var taskFunc = () => backgroundParser.ParseSectionInBackgroundAsync(
+                    section,
+                    backgroundParserStream,
+                    startTick,
+                    endTick,
+                    parser._fullPacketPositions,
+                    setupAction,
+                    cancellationToken);
+
+                //var thread = new Thread(() => taskFunc().GetAwaiter().GetResult());
+                //thread.Start();
+                //threads.Add(thread);
+
+                tasks.Add(Task.Run(taskFunc, cancellationToken));
+
+                sections.Add(section);
+
+                if (reachedLastTick)
+                    break;
+            }
+
+            // start background parser for every section
+            //for (int i = 0; i < parser._fullPacketPositions.Count; i++)
+            //{
+            //    var fullPacketPosition = parser._fullPacketPositions[i];
+
+            //    var backgroundParser = new DemoParser();
+            //    var backgroundParserStream = new MemoryStream(arraySegment.Array!);
+
+            //    DemoTick endTick = i == parser._fullPacketPositions.Count - 1
+            //        ? parser.TickCount
+            //        : parser._fullPacketPositions[i + 1].Tick;
+
+            //    var taskFunc = () => backgroundParser.ParseSectionInBackgroundAsync(
+            //        backgroundParserStream,
+            //        fullPacketPosition.Tick,
+            //        endTick,
+            //        parser._fullPacketPositions,
+            //        setupAction,
+            //        cancellationToken);
+
+            //    //var thread = new Thread(() => taskFunc().GetAwaiter().GetResult());
+            //    //thread.Start();
+            //    //threads.Add(thread);
+
+            //    tasks.Add(Task.Run(taskFunc, cancellationToken));
+            //}
+
+            // wait for all parsers to finish
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            foreach (var thread in threads)
+                thread.Join();
+
+            return new MultiThreadedDemoParsingResult(sections.ToArray());
+        }
+
+        private async Task ParseSectionInBackgroundAsync(
+            MultiThreadedDemoParserSection section,
+            MemoryStream backgroundParserStream,
+            DemoTick startTick,
+            DemoTick endTick,
+            IReadOnlyList<FullPacketRecord> fullPacketPositions,
+            Action<MultiThreadedDemoParserSection>? setupAction,
+            CancellationToken cancellationToken)
+        {
+            var backgroundParser = this;
+
+            await backgroundParser.StartReadingAsync(backgroundParserStream, cancellationToken).ConfigureAwait(false);
+
+            backgroundParser._fullPacketPositions.Clear();
+            backgroundParser._fullPacketPositions.AddRange(fullPacketPositions);
+
+            if (startTick != DemoTick.Zero)
+                await backgroundParser.SeekToTickAsync(startTick, cancellationToken).ConfigureAwait(false);
+
+            // only AFTER we seek to starting tick, allow the user to setup callbacks
+            setupAction?.Invoke(section);
+
+            while (true)
+            {
+                // peek
+                (DemoTick nextTick, EDemoCommands command) = backgroundParser.PeekNext();
+
+                if (nextTick >= endTick) // parser completed his section
+                    break;
+
+                bool hasNext = await backgroundParser.MoveNextAsync(cancellationToken).ConfigureAwait(false);
+                if (!hasNext) // end of file
+                    break;
+            }
+        }
+
+        public (DemoTick nextTick, EDemoCommands command) PeekNext()
+        {
+            var streamPositionBefore = _stream.Position;
+            var commandStartPositionBefore = _commandStartPosition;
+            var demoTickBefore = CurrentDemoTick;
+
+            try
+            {
+                var cmd = ReadCommandHeader();
+                var nextTick = CurrentDemoTick;
+                return (nextTick, cmd.Command);
+            }
+            finally
+            {
+                _commandStartPosition = commandStartPositionBefore;
+                CurrentDemoTick = demoTickBefore;
+                _stream.Position = streamPositionBefore;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Benchmark (6 cores):

| Method      | Job        | Arguments        | Mean       | Error    | StdDev   | Ratio | RatioSD | Gen0       | Gen1       | Gen2      | Allocated | Alloc Ratio |
|------------ |----------- |----------------- |-----------:|---------:|---------:|------:|--------:|-----------:|-----------:|----------:|----------:|------------:|
| ParseDemo   | Job-PEXGNK | /p:Baseline=true | 1,486.5 ms |  6.50 ms |  6.08 ms |  1.00 |    0.00 | 26000.0000 |  1000.0000 |         - |  489.9 MB |        1.00 |
| ParseDemo   | Job-MQEQFA | Default          | 1,485.7 ms |  6.48 ms |  6.06 ms |  1.00 |    0.00 | 26000.0000 |  1000.0000 |         - |  489.9 MB |        1.00 |
|             |            |                  |            |          |          |       |         |            |            |           |           |             |
| ParseDemoMT | Job-PEXGNK | /p:Baseline=true |         NA |       NA |       NA |     ? |       ? |         NA |         NA |        NA |        NA |           ? |
| ParseDemoMT | Job-MQEQFA | Default          |   447.2 ms | 23.40 ms | 21.89 ms |     ? |       ? | 34000.0000 | 11000.0000 | 1000.0000 | 582.88 MB |           ? |
