### PR TITLE
Add support for incomplete demos

### DIFF
--- a/src/DemoFile/DemoFileReader.cs
+++ b/src/DemoFile/DemoFileReader.cs
@@ -30,6 +30,12 @@ public partial class DemoFileReader<TGameParser>
     private long _commandStartPosition;
 
     /// <summary>
+    /// Incomplete demo files have several commands missing at end of file, due to server abruptly shutting down.
+    /// </summary>
+    public bool IsIncompleteFile { get; internal set; }
+    public long IncompleteFileLastStreamPosition { get; internal set; }
+
+    /// <summary>
     /// Event fired every time a demo command is parsed during <see cref="ReadAllAsync(System.Threading.CancellationToken)"/>.
     /// </summary>
     /// <remarks>
@@ -183,7 +189,7 @@ public partial class DemoFileReader<TGameParser>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private (EDemoCommands Command, bool IsCompressed, int Size) ReadCommandHeader()
     {
-        if (_demo.IsIncompleteFile && _stream.Position >= _demo.IncompleteFileLastStreamPosition)
+        if (IsIncompleteFile && _stream.Position >= IncompleteFileLastStreamPosition)
         {
             return (EDemoCommands.DemStop, false, 0);
         }
@@ -268,8 +274,8 @@ public partial class DemoFileReader<TGameParser>
         {
         }
 
-        _demo.IsIncompleteFile = true;
-        _demo.IncompleteFileLastStreamPosition = lastStreamPosition;
+        IsIncompleteFile = true;
+        IncompleteFileLastStreamPosition = lastStreamPosition;
 
         // invoke event
 

--- a/src/DemoFile/DemoFileReader.cs
+++ b/src/DemoFile/DemoFileReader.cs
@@ -185,7 +185,6 @@ public partial class DemoFileReader<TGameParser>
     {
         if (_demo.IsIncompleteFile && _stream.Position >= _demo.IncompleteFileLastStreamPosition)
         {
-            Console.WriteLine($"\n\nIsIncompleteFile hit\n\n");
             return (EDemoCommands.DemStop, false, 0);
         }
 
@@ -244,8 +243,6 @@ public partial class DemoFileReader<TGameParser>
         // performance for MemoryStream: 15 ms for 200K ticks
         // performance for FileStream: 80 ms for 200K ticks
 
-        Stopwatch stopwatch = Stopwatch.StartNew();
-
         var lastTick = DemoTick.Zero;
         var oldStreamPosition = _stream.Position;
         var lastStreamPosition = oldStreamPosition;
@@ -282,10 +279,5 @@ public partial class DemoFileReader<TGameParser>
         _demo.DemoEvents.DemoFileInfo?.Invoke(new CDemoFileInfo() { PlaybackTicks = lastTick.Value });
 
         _stream.Position = oldStreamPosition;
-
-
-
-
-        Console.WriteLine($"elapsed {stopwatch.Elapsed.TotalMilliseconds} ms, for {lastTick.Value / 1000} K ticks");
     }
 }

--- a/src/DemoFile/DemoParser.cs
+++ b/src/DemoFile/DemoParser.cs
@@ -76,6 +76,12 @@ public abstract partial class DemoParser<TGameParser>
     /// </summary>
     public DemoTick TickCount { get; private set; }
 
+    /// <summary>
+    /// Incomplete demo files have several commands missing at end of file, due to server abruptly shutting down.
+    /// </summary>
+    public bool IsIncompleteFile { get; internal set; }
+    public long IncompleteFileLastStreamPosition { get; internal set; }
+
     public TimeSpan Elapsed => TimeSpan.FromSeconds(Math.Max(0, CurrentDemoTick.Value) / 64.0f);
 
     public CSVCMsg_ServerInfo ServerInfo { get; private set; } = new();

--- a/src/DemoFile/DemoParser.cs
+++ b/src/DemoFile/DemoParser.cs
@@ -76,12 +76,6 @@ public abstract partial class DemoParser<TGameParser>
     /// </summary>
     public DemoTick TickCount { get; private set; }
 
-    /// <summary>
-    /// Incomplete demo files have several commands missing at end of file, due to server abruptly shutting down.
-    /// </summary>
-    public bool IsIncompleteFile { get; internal set; }
-    public long IncompleteFileLastStreamPosition { get; internal set; }
-
     public TimeSpan Elapsed => TimeSpan.FromSeconds(Math.Max(0, CurrentDemoTick.Value) / 64.0f);
 
     public CSVCMsg_ServerInfo ServerInfo { get; private set; } = new();


### PR DESCRIPTION
This will provide `TickCount` for incomplete demos, and will prevent exception when reading past end of demo.

Some example demo files:
- https://www.hltv.org/matches/2371121/apeks-vs-gun5-betboom-dacha-belgrade-2024-europe-closed-qualifier
- #43
